### PR TITLE
enable import injection

### DIFF
--- a/stencil.config.ts
+++ b/stencil.config.ts
@@ -9,6 +9,9 @@ export const config: Config = {
 			includePaths: ["./node_modules/"],
     })
 	],
+  extras: {
+    enableImportInjection: true,
+  },
 	outputTargets: [
 		{
 			type: 'dist',


### PR DESCRIPTION
Enabled this flag to be able to use this library in our Vite projects.
This is the same issue we're experiencing: https://github.com/vitejs/vite/issues/12434

Stencil docs for this config option: https://stenciljs.com/docs/config-extras#enableimportinjection